### PR TITLE
Adds all supported distros

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,19 @@ jobs:
       fail-fast: false
       matrix:
         base_distro: [
-          ubuntu-20.04
+          almalinux-8.5,
+          almalinux-8.7,
+          almalinux-9.1,
+          debian-bullseye,
+          debian-buster,
+          fedora-34,
+          fedora-35,
+          fedora-36,
+          leap-15.3,
+          leap-15.4,
+          ubuntu-18.04,
+          ubuntu-20.04,
+          ubuntu-22.04
         ]
 
     steps:

--- a/almalinux-8.5/Dockerfile
+++ b/almalinux-8.5/Dockerfile
@@ -1,44 +1,53 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM almalinux:8.5 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
-  chrpath \
-  cpio \
-  debianutils \
-  diffstat \
-  gawk \
-  gcc \
-  git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
-  python3 \
-  python3-git \
-  python3-jinja2 \
-  python3-pexpect \
-  python3-pip \
-  python3-subunit \
-  socat \
-  texinfo \
-  unzip \
-  wget \
-  xterm \
-  xz-utils \
-  zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+RUN dnf -y update \
+  && dnf -y install epel-release \
+  && dnf config-manager --set-enabled powertools \
+  && dnf makecache \
+  && dnf -y install \
+    SDL-devel \
+    bzip2 \
+    ccache \
+    chrpath \
+    cpp \
+    diffstat \
+    diffutils \
+    gawk \
+    gcc \
+    gcc-c++ \
+    git \
+    glibc-devel \
+    gzip \
+    lz4 \
+    make \
+    mesa-libGL-devel \
+    patch \
+    perl \
+    perl-Data-Dumper \
+    perl-Text-ParseWords \
+    perl-Thread-Queue \
+    python3 \
+    python3-GitPython \
+    python3-jinja2 \
+    python3-pexpect \
+    python3-pip \
+    rpcgen \
+    socat \
+    tar \
+    texinfo \
+    unzip \
+    wget \
+    which \
+    xterm \
+    xz \
+    zstd \
+  && dnf clean all
 
 # Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
+RUN dnf -y update && dnf -y install \
+  glibc-langpack-en \
+  && dnf clean all
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -61,10 +70,6 @@ RUN \
 
 
 FROM base as development
-
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/almalinux-8.7/Dockerfile
+++ b/almalinux-8.7/Dockerfile
@@ -1,44 +1,53 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM almalinux:8.7 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
-  chrpath \
-  cpio \
-  debianutils \
-  diffstat \
-  gawk \
-  gcc \
-  git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
-  python3 \
-  python3-git \
-  python3-jinja2 \
-  python3-pexpect \
-  python3-pip \
-  python3-subunit \
-  socat \
-  texinfo \
-  unzip \
-  wget \
-  xterm \
-  xz-utils \
-  zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+RUN dnf -y update \
+  && dnf -y install epel-release \
+  && dnf config-manager --set-enabled powertools \
+  && dnf makecache \
+  && dnf -y install \
+    SDL-devel \
+    bzip2 \
+    ccache \
+    chrpath \
+    cpp \
+    diffstat \
+    diffutils \
+    gawk \
+    gcc \
+    gcc-c++ \
+    git \
+    glibc-devel \
+    gzip \
+    lz4 \
+    make \
+    mesa-libGL-devel \
+    patch \
+    perl \
+    perl-Data-Dumper \
+    perl-Text-ParseWords \
+    perl-Thread-Queue \
+    python3 \
+    python3-GitPython \
+    python3-jinja2 \
+    python3-pexpect \
+    python3-pip \
+    rpcgen \
+    socat \
+    tar \
+    texinfo \
+    unzip \
+    wget \
+    which \
+    xterm \
+    xz \
+    zstd \
+  && dnf clean all
 
 # Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
+RUN dnf -y update && dnf -y install \
+  glibc-langpack-en \
+  && dnf clean all
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -61,10 +70,6 @@ RUN \
 
 
 FROM base as development
-
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/almalinux-9.1/Dockerfile
+++ b/almalinux-9.1/Dockerfile
@@ -1,44 +1,56 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM almalinux:9.1 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
-  chrpath \
-  cpio \
-  debianutils \
-  diffstat \
-  gawk \
-  gcc \
-  git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
-  python3 \
-  python3-git \
-  python3-jinja2 \
-  python3-pexpect \
-  python3-pip \
-  python3-subunit \
-  socat \
-  texinfo \
-  unzip \
-  wget \
-  xterm \
-  xz-utils \
-  zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+RUN dnf -y update \
+  && dnf -y install epel-release \
+  && dnf -y install 'dnf-command(config-manager)' \
+  && dnf config-manager --set-enabled crb \
+  && dnf makecache \
+  && dnf -y install \
+    SDL-devel \
+    bzip2 \
+    ccache \
+    chrpath \
+    cpp \
+    diffstat \
+    diffutils \
+    gawk \
+    gcc \
+    gcc-c++ \
+    git \
+    glibc-devel \
+    gzip \
+    lz4 \
+    make \
+    mesa-libGL-devel \
+    patch \
+    perl \
+    perl-Data-Dumper \
+    perl-Text-ParseWords \
+    perl-Thread-Queue \
+    python3 \
+    python3-GitPython \
+    python3-jinja2 \
+    python3-pexpect \
+    python3-pip \
+    rpcgen \
+    socat \
+    tar \
+    texinfo \
+    unzip \
+    wget \
+    which \
+    xterm \
+    xz \
+    zstd \
+  && dnf clean all
+
+RUN dnf -y install cpio
 
 # Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
+RUN dnf -y update && dnf -y install \
+  glibc-langpack-en \
+  && dnf clean all
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -61,10 +73,6 @@ RUN \
 
 
 FROM base as development
-
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/debian-bullseye/Dockerfile
+++ b/debian-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM debian:bullseye as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,6 +9,7 @@ RUN apt update && apt install -y \
   cpio \
   debianutils \
   diffstat \
+  file \
   gawk \
   gcc \
   git \

--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM debian:buster as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/fedora-34/Dockerfile
+++ b/fedora-34/Dockerfile
@@ -1,44 +1,59 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM fedora:34 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
+RUN dnf -y update && dnf -y install \
+  SDL-devel \
+  bzip2 \
+  ccache \
   chrpath \
   cpio \
-  debianutils \
+  cpp \
   diffstat \
+  diffutils \
+  file \
+  findutils \
   gawk \
   gcc \
+  gcc-c++ \
   git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
+  glibc-devel \
+  gzip \
+  hostname \
+  lz4 \
+  make \
+  mesa-libGL-devel \
+  patch \
+  perl \
+  perl-Data-Dumper \
+  perl-File-Compare \
+  perl-File-Copy \
+  perl-FindBin \
+  perl-Text-ParseWords \
+  perl-Thread-Queue \
+  perl-bignum \
+  perl-locale \
+  python \
   python3 \
-  python3-git \
+  python3-GitPython \
   python3-jinja2 \
   python3-pexpect \
   python3-pip \
-  python3-subunit \
+  rpcgen \
   socat \
+  tar \
   texinfo \
   unzip \
   wget \
+  which \
   xterm \
-  xz-utils \
+  xz \
   zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+  && dnf clean all
 
 # Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
+RUN dnf -y update && dnf -y install \
+  glibc-langpack-en \
+  && dnf clean all
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -61,10 +76,6 @@ RUN \
 
 
 FROM base as development
-
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/fedora-35/Dockerfile
+++ b/fedora-35/Dockerfile
@@ -1,44 +1,59 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM fedora:35 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
+RUN dnf -y update && dnf -y install \
+  SDL-devel \
+  bzip2 \
+  ccache \
   chrpath \
   cpio \
-  debianutils \
+  cpp \
   diffstat \
+  diffutils \
+  file \
+  findutils \
   gawk \
   gcc \
+  gcc-c++ \
   git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
+  glibc-devel \
+  gzip \
+  hostname \
+  lz4 \
+  make \
+  mesa-libGL-devel \
+  patch \
+  perl \
+  perl-Data-Dumper \
+  perl-File-Compare \
+  perl-File-Copy \
+  perl-FindBin \
+  perl-Text-ParseWords \
+  perl-Thread-Queue \
+  perl-bignum \
+  perl-locale \
+  python \
   python3 \
-  python3-git \
+  python3-GitPython \
   python3-jinja2 \
   python3-pexpect \
   python3-pip \
-  python3-subunit \
+  rpcgen \
   socat \
+  tar \
   texinfo \
   unzip \
   wget \
+  which \
   xterm \
-  xz-utils \
+  xz \
   zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+  && dnf clean all
 
 # Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
+RUN dnf -y update && dnf -y install \
+  glibc-langpack-en \
+  && dnf clean all
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -61,10 +76,6 @@ RUN \
 
 
 FROM base as development
-
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/fedora-36/Dockerfile
+++ b/fedora-36/Dockerfile
@@ -1,44 +1,59 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM fedora:36 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
+RUN dnf -y update && dnf -y install \
+  SDL-devel \
+  bzip2 \
+  ccache \
   chrpath \
   cpio \
-  debianutils \
+  cpp \
   diffstat \
+  diffutils \
+  file \
+  findutils \
   gawk \
   gcc \
+  gcc-c++ \
   git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
+  glibc-devel \
+  gzip \
+  hostname \
+  lz4 \
+  make \
+  mesa-libGL-devel \
+  patch \
+  perl \
+  perl-Data-Dumper \
+  perl-File-Compare \
+  perl-File-Copy \
+  perl-FindBin \
+  perl-Text-ParseWords \
+  perl-Thread-Queue \
+  perl-bignum \
+  perl-locale \
+  python \
   python3 \
-  python3-git \
+  python3-GitPython \
   python3-jinja2 \
   python3-pexpect \
   python3-pip \
-  python3-subunit \
+  rpcgen \
   socat \
+  tar \
   texinfo \
   unzip \
   wget \
+  which \
   xterm \
-  xz-utils \
+  xz \
   zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+  && dnf clean all
 
 # Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
+RUN dnf -y update && dnf -y install \
+  glibc-langpack-en \
+  && dnf clean all
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -61,10 +76,6 @@ RUN \
 
 
 FROM base as development
-
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/leap-15.3/Dockerfile
+++ b/leap-15.3/Dockerfile
@@ -1,50 +1,41 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM opensuse/leap:15.3 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
+RUN zypper --non-interactive update && zypper --non-interactive install \
+  Mesa-dri-devel \
+  Mesa-libEGL1 \
   chrpath \
-  cpio \
-  debianutils \
   diffstat \
-  gawk \
   gcc \
+  gcc-c++ \
   git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
+  libSDL-devel \
+  lz4 \
+  make \
+  makeinfo \
+  patch \
+  python \
+  python-curses \
+  python-xml \
   python3 \
-  python3-git \
-  python3-jinja2 \
+  python3-Jinja2 \
+  python3-curses \
   python3-pexpect \
   python3-pip \
-  python3-subunit \
+  rpcgen \
   socat \
-  texinfo \
-  unzip \
+  tar \
   wget \
+  which \
   xterm \
-  xz-utils \
+  xz \
   zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+  && zypper clean
 
-# Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+RUN pip3 install GitPython
 
 # Can't run bitbake as root
-RUN useradd --create-home chef
+RUN useradd --user-group --create-home chef
 
 
 FROM base as test
@@ -62,9 +53,10 @@ RUN \
 
 FROM base as development
 
-RUN apt update && apt install -y \
+RUN zypper --non-interactive update && zypper --non-interactive install \
   curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+  gzip \
+  && zypper clean
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/leap-15.4/Dockerfile
+++ b/leap-15.4/Dockerfile
@@ -1,50 +1,41 @@
-FROM ubuntu:20.04 as base
-
-ARG DEBIAN_FRONTEND=noninteractive
+FROM opensuse/leap:15.4 as base
 
 # [Required packages for build host](https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian)
-RUN apt update && apt install -y \
-  build-essential \
+RUN zypper --non-interactive update && zypper --non-interactive install \
+  Mesa-dri-devel \
+  Mesa-libEGL1 \
   chrpath \
-  cpio \
-  debianutils \
   diffstat \
-  gawk \
   gcc \
+  gcc-c++ \
   git \
-  iputils-ping \
-  libegl1-mesa \
-  liblz4-tool \
-  libsdl1.2-dev \
-  mesa-common-dev \
-  pylint3 \
+  libSDL-devel \
+  lz4 \
+  make \
+  makeinfo \
+  patch \
+  python \
+  python-curses \
+  python-xml \
   python3 \
-  python3-git \
-  python3-jinja2 \
+  python3-Jinja2 \
+  python3-curses \
   python3-pexpect \
   python3-pip \
-  python3-subunit \
+  rpcgen \
   socat \
-  texinfo \
-  unzip \
+  tar \
   wget \
+  which \
   xterm \
-  xz-utils \
+  xz \
   zstd \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+  && zypper clean
 
-# Locale setup
-RUN apt update && apt install -y \
-  locales \
-  && apt clean && rm -rf /var/lib/apt/lists/*
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-  && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+RUN pip3 install GitPython
 
 # Can't run bitbake as root
-RUN useradd --create-home chef
+RUN useradd --user-group --create-home chef
 
 
 FROM base as test
@@ -62,9 +53,9 @@ RUN \
 
 FROM base as development
 
-RUN apt update && apt install -y \
-  curl \
-  && apt clean && rm -rf /var/lib/apt/lists/*
+RUN zypper --non-interactive update && zypper --non-interactive install \
+  gzip \
+  && zypper clean
 
 # Setup [fixuid](https://github.com/boxboat/fixuid)
 RUN USER=chef && \

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,14 @@
 # General
 
-A container which supports building Yocto images.
+Dockerfiles which provide containerized build hosts for the [Yocto Project](https://www.yoctoproject.org/).
+
+# How is this different than crops?
+
+[crops](https://github.com/crops) are the official Yocto Project containerized
+build hosts. However, they only support the most recent Yocto Project releases.
+Professionally, I work on older releases and the crops images do not (promise
+to) work with older releases. This project aims to support older releases as
+well as newer releases.
 
 # Running tests
 
@@ -11,19 +19,16 @@ user@host$ docker build --target test <base-distro>
 # Usage
 
 
-This is still very early in development, but one can build an image like so...
+One can build poky like so...
 
 ```
-user@host$ docker build --target base -t yocto_ubuntu:4.1.3_20.04 ubuntu-20.04
-user@host$ docker run --rm -it -v myvolume:/workdir ubuntu:20.04
-root@ubuntu$ mkdir /workdir/poky
-root@ubuntu$ chown 1000:1000 /workdir/poky
-user@host$ docker run --rm -it -v myvolume:/workdir yocto_ubuntu:4.1.3_20.04
-chef@yocto_ubuntu$ source /opt/poky/4.1.3/environment-setup-x86_64-pokysdk-linux
-chef@yocto_ubuntu$ cd /workdir/poky
-chef@yocto_ubuntu$ git clone git://git.yoctoproject.org/poky .
-chef@yocto_ubuntu$ git checkout -t origin/langdale -b my-langdale
-chef@yocto_ubuntu$ source oe-init-build-env
-chef@yocto_ubuntu$ bitbake core-image-minimal
+user@host$ docker build --target development -t yocto_ubuntu_dev:4.1.3_20.04 ubuntu-20.04
+user@host$ docker run --rm -it -v myvolume:/home/chef yocto_ubuntu_dev:4.1.3_20.04 bash
+chef@yocto_ubuntu_dev$ git clone git://git.yoctoproject.org/poky poky
+chef@yocto_ubuntu_dev$ cd poky
+chef@yocto_ubuntu_dev$ source oe-init-build-env
+chef@yocto_ubuntu_dev$ bitbake core-image-minimal
 ```
+
+`myvolume` will contain the build artifacts.
 

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM ubuntu:18.04 as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM ubuntu:22.04 as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,6 +9,7 @@ RUN apt update && apt install -y \
   cpio \
   debianutils \
   diffstat \
+  file \
   gawk \
   gcc \
   git \
@@ -17,7 +18,7 @@ RUN apt update && apt install -y \
   liblz4-tool \
   libsdl1.2-dev \
   mesa-common-dev \
-  pylint3 \
+  pylint \
   python3 \
   python3-git \
   python3-jinja2 \


### PR DESCRIPTION
Adds all distros supported by the `master` branch, including...
- Ubuntu 18.04
- Ubuntu 20.04
- Ubuntu 22.04
- Debian Buster (10.x)
- Debian Bullseye (11.x)
- Fedora 34
- Fedora 35
- Fedora 36
- AlmaLinux 8.5
- AlmaLinux 8.7
- AlmaLinux 9.1
- openSUSE Leap 15.3
- openSUSE Leap 15.4

It should be noted that since Yocto `buildtools` are not installed, the following distros are unable to pass tests...
- Ubuntu 18.04
- Debian Buster (10.x)
- AlmaLinux 8.5
- AlmaLinux 8.7
- openSUSE Leap 15.3
- openSUSE Leap 15.4