### PR TITLE
Reduce disk usage

### DIFF
--- a/almalinux-8.7/Dockerfile
+++ b/almalinux-8.7/Dockerfile
@@ -71,6 +71,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/almalinux-9.1/Dockerfile
+++ b/almalinux-9.1/Dockerfile
@@ -69,6 +69,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/buildtools/Dockerfile
+++ b/buildtools/Dockerfile
@@ -58,6 +58,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake buildtools-tarball buildtools-extended-tarball buildtools-make-tarball
 
 

--- a/debian-bullseye/Dockerfile
+++ b/debian-bullseye/Dockerfile
@@ -58,6 +58,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/fedora-36/Dockerfile
+++ b/fedora-36/Dockerfile
@@ -72,6 +72,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/fedora-37/Dockerfile
+++ b/fedora-37/Dockerfile
@@ -72,6 +72,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/leap-15.3/Dockerfile
+++ b/leap-15.3/Dockerfile
@@ -56,6 +56,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/leap-15.4/Dockerfile
+++ b/leap-15.4/Dockerfile
@@ -56,6 +56,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -62,6 +62,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -57,6 +57,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -58,6 +58,7 @@ RUN \
   && cd poky \
   && git checkout master \
   && . ./oe-init-build-env \
+  && echo INHERIT += \"rm_work\" >> conf/local.conf \
   && bitbake quilt-native
 
 


### PR DESCRIPTION
Bitbake configurations now inherit from "rm-work" to reduce disk usage during builds.